### PR TITLE
Set open to false after checking event.target

### DIFF
--- a/source/j/main.js
+++ b/source/j/main.js
@@ -420,13 +420,14 @@
     
     function closeSearch( e ) {
         if ( ! open ) { return false; }
-        open = false;
         
         var target_tag = e.target.nodeName.toLowerCase();
         if ( target_tag == 'button' ||
              target_tag == 'input' ) {
             return false;
-        } 
+        }
+        
+        open = false;
         
         e.preventDefault();
         window.location.hash = '#';


### PR DESCRIPTION
`open = false` was set before checking `event.target`, resulting in a search form that could not be closed if the input field was clicked/tapped first.